### PR TITLE
Compile error fixes for Xcode 12 / iOS 14

### DIFF
--- a/SpokestackTray/Controllers/LogController.swift
+++ b/SpokestackTray/Controllers/LogController.swift
@@ -9,6 +9,7 @@ import Foundation
 #if !os(iOS)
 import OSLog
 #endif
+import os
 
 public class LogController {
     


### PR DESCRIPTION
Adding the import for the `os` framework fixes the support for iOS 13 and 14